### PR TITLE
refactor: moved fetching SQL rules problems to base class for clearner tests

### DIFF
--- a/SqlServer.Rules.Test/Performance/PerformanceTestCases.cs
+++ b/SqlServer.Rules.Test/Performance/PerformanceTestCases.cs
@@ -14,39 +14,18 @@ namespace SqlServer.Rules.Tests.Performance
     [TestCategory("Performance")]
     public class PerformanceTestCases : TestCasesBase
     {
-        public TestContext TestContext { get; set; }
-
         [TestMethod]
         public void TestNonSARGablePattern()
         {
-            string testCases = "AvoidNonsargableLikePattern";
+            var problems = GetTestCaseProblems("AvoidNonsargableLikePattern", AvoidEndsWithOrContainsRule.RuleId);
 
-            using (var test = new BaselineSetup(TestContext, testCases, new TSqlModelOptions(), SqlVersion))
-            {
-                try
-                {
-                    test.RunTest(AvoidEndsWithOrContainsRule.RuleId, (result, problemString) =>
-                    {
-                        var problems = result.Problems;
+            Assert.AreEqual(2, problems.Count, "Expected 2 problem to be found");
 
-                        Assert.AreEqual(2, problems.Count, "Expected 2 problem to be found");
+            Assert.IsTrue(problems.Any(problem => Comparer.Equals(problem.SourceName, "nonsargable.sql")));
+            Assert.IsTrue(problems.Any(problem => Comparer.Equals(problem.SourceName, "nonsargable2.sql")));
 
-                        Assert.IsTrue(problems.Any(problem => Comparer.Equals(problem.SourceName, "nonsargable.sql")));
-                        Assert.IsTrue(problems.Any(problem => Comparer.Equals(problem.SourceName, "nonsargable2.sql")));
-
-                        Assert.IsTrue(problems.All(problem => Comparer.Equals(problem.Description, AvoidEndsWithOrContainsRule.Message)));
-                        Assert.IsTrue(problems.All(problem => problem.Severity == SqlRuleProblemSeverity.Warning));
-                    });
-                }
-                catch (AssertFailedException)
-                {
-                    throw;
-                }
-                catch(Exception ex)
-                {
-                    Assert.Fail($"Exception thrown in '{nameof(TestNonSARGablePattern)}' for test cases '{testCases}': {ex.Message}");
-                }
-            }
+            Assert.IsTrue(problems.All(problem => Comparer.Equals(problem.Description, AvoidEndsWithOrContainsRule.Message)));
+            Assert.IsTrue(problems.All(problem => problem.Severity == SqlRuleProblemSeverity.Warning));
         }
     }
 }

--- a/SqlServer.Rules.Test/TestCasesBase.cs
+++ b/SqlServer.Rules.Test/TestCasesBase.cs
@@ -1,6 +1,11 @@
-﻿using Microsoft.SqlServer.Dac.Model;
+﻿using Microsoft.SqlServer.Dac.CodeAnalysis;
+using Microsoft.SqlServer.Dac.Model;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SqlServer.Rules.Test;
 using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace SqlServer.Rules.Tests
 {
@@ -9,5 +14,26 @@ namespace SqlServer.Rules.Tests
     {
         protected const SqlServerVersion SqlVersion = SqlServerVersion.Sql130;
         protected StringComparer Comparer = StringComparer.OrdinalIgnoreCase;
+
+        public TestContext TestContext { get; set; }
+
+        protected ReadOnlyCollection<SqlRuleProblem> GetTestCaseProblems(string testCases, string ruleId)
+        {
+            ReadOnlyCollection<SqlRuleProblem> problems = new ReadOnlyCollection<SqlRuleProblem>(new List<SqlRuleProblem>());
+
+            using (var test = new BaselineSetup(TestContext, testCases, new TSqlModelOptions(), SqlVersion))
+            {
+                try
+                {
+                    test.RunTest(ruleId, (result, problemString) => problems = result.Problems);
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Exception thrown for ruleId '{ruleId}' for test cases '{testCases}': {ex.Message}");
+                }
+            }
+
+            return problems;
+        }
     }
 }


### PR DESCRIPTION
@tcartwright,

I moved the fetching of problems to the base class so that the unit tests aren't burdened by the try/catch and disposals. It should make the test cases cleaner and easier to read/write, but I am not 100% on my execution. The base class looks a bit messy, so it might need some touch-ups itself.

Let me know what you think.